### PR TITLE
Update Linux/Android API key in README.md and xbv.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ print(header_value)
 | Platform | Default Key (found in Chrome binaries)    |
 | -------- | ----------------------------------------- |
 | Windows  | `AIzaSyA2KlwBX3mkFo30om9LUFYQhpqLoa_BNhE` |
-| Linux    | `AIzaSyBqJZh-7pA44blAaAkH6490hUFOwX0KCYM` |
+| Linux    | `AIzaSyDlUur5xXJ0gBeLFW_D2PtjduqOFQMsqEY` |
 | macOS    | `AIzaSyDr2UxVnv_U85AbhhY8XSHSIavUW0DC-sY` |
 
 ---

--- a/xbv.py
+++ b/xbv.py
@@ -3,7 +3,7 @@ import base64
 
 PLATFORM_API_KEYS = {
     "windows": "AIzaSyA2KlwBX3mkFo30om9LUFYQhpqLoa_BNhE",
-    "linux":   "AIzaSyBqJZh-7pA44blAaAkH6490hUFOwX0KCYM",
+    "linux":   "AIzaSyDlUur5xXJ0gBeLFW_D2PtjduqOFQMsqEY",
     "macos":   "AIzaSyDr2UxVnv_U85AbhhY8XSHSIavUW0DC-sY",
 }
 


### PR DESCRIPTION
I spent half a day figuring out the reason why Android 'x-browser-validation' header value didn't match. 
After investigation, I've found correct Android/Linux platform Chrome API key that works and the result matches real world values.